### PR TITLE
Change brightness to allow white saturation

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -2668,8 +2668,17 @@ SpriteMorph.prototype.setBrightness = function (num) {
         x = this.xPosition(),
         y = this.yPosition();
 
-    hsv[1] = 1; // we gotta fix this at some time
-    hsv[2] = Math.max(Math.min(+num || 0, 100), 0) / 100;
+    num = Math.max(Math.min(+num || 0, 200), 0) / 100;
+    hsv[1] = 1;
+    hsv[2] = 1;
+
+    if(num > 1) {
+        hsv[1] = (2 - num);
+    }
+    else {
+        hsv[2] = num;
+    }
+
     this.color.set_hsv.apply(this.color, hsv);
     if (!this.costume) {
         this.drawNew();
@@ -2677,6 +2686,7 @@ SpriteMorph.prototype.setBrightness = function (num) {
     }
     this.gotoXY(x, y);
 };
+
 
 SpriteMorph.prototype.changeBrightness = function (delta) {
     this.setBrightness(this.getBrightness() + (+delta || 0));


### PR DESCRIPTION
Note that in the conversion here http://www.rapidtables.com/convert/color/hsv-to-rgb.htm hue determines color on the roygbv spectrum (0 to 100). With saturation at 100, value changes from black (value=0) to the color specified by hue (value=100). Once value reaches 100, the only way to go from that color to white is to leave value at 100 and start dropping saturation--when it reaches zero, you get white. So that is what the code does. Since the user does not have separate saturation and value controls--she can only control "shade"--the code takes any shade from 0 to 100 as increasing the value from 0 to 100, and any shade from 100 to 200 as decreasing the saturation from 100 to 0.